### PR TITLE
[RFC] process to separate rocq

### DIFF
--- a/language-server/dm/dune
+++ b/language-server/dm/dune
@@ -4,7 +4,7 @@
  (modules :standard \ vscoqtop_proof_worker vscoqtop_tactic_worker)
  (preprocess (pps ppx_optcomp -- -cookie "ppx_optcomp.env=env ~coq:(Defined \"%{coq:version.major}.%{coq:version.minor}\")"))
  (preprocessor_deps vscoq_config.mlh)
- (libraries base coq-core.sysinit coq-core.vernac coq-core.parsing lsp sel protocol language))
+ (libraries base host coq-core.sysinit coq-core.vernac coq-core.parsing lsp sel protocol language))
 
 (executable
  (name vscoqtop_proof_worker)

--- a/language-server/dm/rawDocument.ml
+++ b/language-server/dm/rawDocument.ml
@@ -12,6 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 open Lsp.Types
+open Types
 
 type text_edit = Range.t * string
 

--- a/language-server/dm/rawDocument.ml
+++ b/language-server/dm/rawDocument.ml
@@ -12,6 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 open Lsp.Types
+open Host
 open Types
 
 type text_edit = Range.t * string
@@ -83,8 +84,8 @@ let end_loc raw =
 
 let range_of_loc raw loc =
   let open Range in
-  { start = position_of_loc raw loc.Loc.bp;
-    end_ = position_of_loc raw loc.Loc.ep;
+  { start = position_of_loc raw (HLoc.get_begin loc);
+    end_ = position_of_loc raw (HLoc.get_end loc);
   }
 
 let word_at_position raw pos : string option =

--- a/language-server/dm/rawDocument.mli
+++ b/language-server/dm/rawDocument.mli
@@ -12,6 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 open Lsp.Types
+open Host
 open Types
 
 type text_edit = Range.t * string
@@ -25,7 +26,7 @@ val position_of_loc : t -> int -> Position.t
 val loc_of_position : t -> Position.t -> int
 val end_loc : t -> int
 
-val range_of_loc : t -> Loc.t -> Range.t
+val range_of_loc : t -> HLoc.t -> Range.t
 val word_at_position: t -> Position.t -> string option
 val string_in_range: t -> int -> int -> string
 

--- a/language-server/dm/rawDocument.mli
+++ b/language-server/dm/rawDocument.mli
@@ -12,6 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 open Lsp.Types
+open Types
 
 type text_edit = Range.t * string
 

--- a/language-server/dm/types.ml
+++ b/language-server/dm/types.ml
@@ -13,6 +13,11 @@
 (**************************************************************************)
 open Protocol.LspWrapper
 
+module Loc = struct
+  include Loc
+end
+[@@deprecated "use a proxy in host/"]
+
 type sentence_id = Stateid.t
 type sentence_id_set = Stateid.Set.t
 

--- a/language-server/host/dune
+++ b/language-server/host/dune
@@ -1,0 +1,6 @@
+(library
+ (name host)
+ (public_name vscoq-language-server.host)
+ (wrapped true)
+ (preprocess (pps ppx_optcomp -- -cookie "ppx_optcomp.env=env ~coq:(Defined \"%{coq:version.major}.%{coq:version.minor}\")"))
+ (libraries coq-core.gramlib coq-core.boot coq-core.sysinit coq-core.vernac coq-core.kernel coq-core.engine coq-core.pretyping coq-core.printing coq-core.parsing coq-core.interp coq-core.lib coq-core.clib coq-core.library coq-core.proofs coq-core.tactics protocol sel lsp))

--- a/language-server/host/hLoc.ml
+++ b/language-server/host/hLoc.ml
@@ -1,0 +1,3 @@
+type t = Loc.t
+let get_begin t = t.Loc.bp
+let get_end t = t.Loc.ep


### PR DESCRIPTION
This is an attempt to establish a strategy to separate, step by step, Rocq specific code.
Idea:
- `open Types` is almost everywhere (make this everywhere)
- shadow a Rocq module and deprecate it
- make a proxy in the host/ component, eg HLoc for Loc and expose a minimal, meaningful, set of APIs
- replace uses of Loc with HLoc
- repeat